### PR TITLE
Filter request body

### DIFF
--- a/.eslintignore
+++ b/.eslintignore
@@ -1,0 +1,2 @@
+coverage
+node_modules

--- a/lib/hock.js
+++ b/lib/hock.js
@@ -8,7 +8,8 @@ const doesBodyMatch = require('./util/doesBodyMatch');
  *
  * @param {object}      [options]       options for your Hock server
  * @param {boolean}     [options.throwOnUnmatched]  Tell Hock to throw if receiving a request without a match (default=true)
- * @param {boolean}     [options.throwOnUnprocessedRequests]  Tell Hock to throw if there are unprocessed requests in the assertion queue (default=true)
+ * @param {boolean}     [options.throwOnUnprocessedRequests]  Tell Hock to throw
+ * if there are unprocessed requests in the assertion queue (default=true)
  *
  * @type {Function}
  */
@@ -16,7 +17,8 @@ class Hock {
     constructor(options) {
         options = options || {};
         this._throwOnUnmatched = (typeof options.throwOnUnmatched === 'boolean' ? options.throwOnUnmatched : true);
-        this._throwOnUnprocessedRequests = (typeof options.throwOnUnprocessedRequests === 'boolean' ? options.throwOnUnprocessedRequests : true);
+        this._throwOnUnprocessedRequests = (typeof options.throwOnUnprocessedRequests === 'boolean' ?
+            options.throwOnUnprocessedRequests : true);
 
         this._assertions = [];
         this.handler = Hock.prototype.handler.bind(this);
@@ -84,7 +86,8 @@ class Hock {
             this._assertions = this._assertions.filter((request) => request.isDone());
 
             if (this._assertions.length) {
-                err = new Error('Unprocessed Requests in Assertions Queue: \n' + JSON.stringify(this._assertions.map((item) => item.method + ' ' + item.url)));
+                err = new Error('Unprocessed Requests in Assertions Queue: \n' +
+                    JSON.stringify(this._assertions.map((item) => item.method + ' ' + item.url)));
             }
         }
 

--- a/lib/request.js
+++ b/lib/request.js
@@ -307,4 +307,4 @@ module.exports = class Request {
             }
         };
     }
-}
+};

--- a/lib/request.js
+++ b/lib/request.js
@@ -184,6 +184,10 @@ module.exports = class Request {
             return this.method === request.method && request.url === this.url && this._checkHeaders(request);
         }
         else {
+            if (this._parent._requestFilter) {
+                request.body = this._parent._requestFilter(request.body);
+            }
+
             return this.method === request.method && this.url === request.url &&
                 doesBodyMatch(this.body, request.body) && this._checkHeaders(request);
         }

--- a/lib/util/doesBodyMatch.js
+++ b/lib/util/doesBodyMatch.js
@@ -19,4 +19,4 @@ module.exports = function doesBodyMatch(bodyA, bodyB) {
     catch (e) { // Error parsing, compare strings.
         return bodyA === bodyB;
     }
-}
+};


### PR DESCRIPTION
Added back one if statement (https://github.com/mmalecki/hock/blob/master/lib/request.js#L208) from hock so that it would be possible to use `filteringRequestBodyRegEx` functionality.

This was removed in: https://github.com/zeroturnaround/zt-hock/commit/33b0e38b329524bec341ad90f19eded3883027b3?diff=split#diff-96d9811cb2296e877edf463c6cfc57bdL178