### PR TITLE
Changed HTTP status code

### DIFF
--- a/lib/hock.js
+++ b/lib/hock.js
@@ -334,7 +334,7 @@ class Hock {
                 if (req.method === 'PUT' || req.method === 'PATCH' || req.method === 'POST') {
                     console.error(req.body); // eslint-disable-line
                 }
-                res.writeHead(500, { 'Content-Type': 'text/plain' });
+                res.writeHead(404, { 'Content-Type': 'text/plain' });
                 res.end('No Matching Response!\n');
             }
             else {

--- a/test/simple-test.js
+++ b/test/simple-test.js
@@ -410,4 +410,30 @@ describe('Hock HTTP Tests', function() {
             });
         });
     });
+
+    describe("when throwOnUnmatched is set to false", function() {
+        beforeEach(function(done) {
+            this.port = createPort();
+            this.hockInstance = hock.createHock({throwOnUnmatched: false});
+            this.httpServer = createHttpServer(this.hockInstance, this.port, done);
+        });
+
+        afterEach(function(done) {
+            this.httpServer.close(done);
+        });
+
+        it('should correctly respond to a missing request', function(done) {
+            catchErrors(done, () => {
+                request('http://localhost:' + this.port + '/notUrl',
+                    (err, res, body) => {
+                        expect(err).toBeFalsy();
+                        expect(res).not.toBe(undefined);
+                        expect(res.headers['content-type']).toEqual("text/plain");
+                        expect(res.statusCode).toEqual(404);
+                        expect(body).toEqual("No Matching Response!\n");
+                        done();
+                    });
+            });
+        });
+    });
 });


### PR DESCRIPTION
Currently, a 500 code is given for a missing URI. Should be a 404 instead.