### PR TITLE
Pass whole request instead of only body.

### DIFF
--- a/lib/hock.js
+++ b/lib/hock.js
@@ -240,11 +240,11 @@ class Hock {
      * @returns {Hock}
      */
     filteringRequestBodyRegEx(source, replace) {
-        this._requestFilter = function(path) {
-            if (path) {
-                path = path.replace(source, replace);
+        this._requestFilter = function({body}) {
+            if (body) {
+                body = body.replace(source, replace);
             }
-            return path;
+            return body;
         };
 
         return this;

--- a/lib/request.js
+++ b/lib/request.js
@@ -185,7 +185,7 @@ module.exports = class Request {
         }
         else {
             if (this._parent._requestFilter) {
-                request.body = this._parent._requestFilter(request.body);
+                request.body = this._parent._requestFilter(request);
             }
 
             return this.method === request.method && this.url === request.url &&

--- a/test/simple-test.js
+++ b/test/simple-test.js
@@ -322,8 +322,9 @@ describe('Hock HTTP Tests', function() {
 
         it('should correctly use functions', function(done) {
             this.hockInstance
-                .filteringRequestBody(function(body) {
+                .filteringRequestBody(function({body, url}) {
                     expect(body).toEqual(JSON.stringify({numbers: '123'}));
+                    expect(url).toEqual("/post");
                     return JSON.stringify({numbers: 'numbers-stripped'});
                 })
                 .post('/post', { numbers: 'numbers-stripped' })


### PR DESCRIPTION
PS! This is backwards incompatible, but XRebel/QRebel don't use
filteringRequestBody or filteringRequestBodyRegEx.